### PR TITLE
Clean up the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+build/

--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,1 @@
-# Binaries for programs and plugins
-*.exe
-*.exe~
-*.dll
-*.so
-*.dylib
-
-# Test binary, built with `go test -c`
-*.test
-
-# Output of the go coverage tool, specifically when used with LiteIDE
-*.out
-
-# Dependency directories (remove the comment below to include it)
-# vendor/
 .idea/


### PR DESCRIPTION
Gitignore should contain only rules that exist in our system